### PR TITLE
Add constant extenders in general and for duplex containers

### DIFF
--- a/const_extenders.txt
+++ b/const_extenders.txt
@@ -1,282 +1,293 @@
-Rd = memb(##U32)
-Rd = memub(##U32)
-Rd = memh(##U32)
-Rd = memuh(##U32)
-Rd = memw(##U32)
-Rd = memd(##U32)
-if (Pt) Rd = memb (Rs + #u6:0) // +
-if (!Pt) Rd = memb (Rs + #u6:0) // +
-if (Pt.new) Rd = memb (Rs + #u6:0) // +
-if (!Pt.new) Rd = memb (Rs + #u6:0) // +
-if (Pt) Rd = memub (Rs + #u6:0) // +
-if (!Pt) Rd = memub (Rs + #u6:0) // +
-if (Pt.new) Rd = memub (Rs + #u6:0) // +
-if (!Pt.new) Rd = memub (Rs + #u6:0) // +
-if (Pt) Rd = memh (Rs + #u6:1) // +
-if (!Pt) Rd = memh (Rs + #u6:1) // +
-if (Pt.new) Rd = memh (Rs + #u6:1) // +
-if (!Pt.new) Rd = memh (Rs + #u6:1) // +
-if (Pt) Rd = memuh (Rs + #u6:1) // +
-if (!Pt) Rd = memuh (Rs + #u6:1) // +
-if (Pt.new) Rd = memuh (Rs + #u6:1) // +
-if (!Pt.new) Rd = memuh (Rs + #u6:1) // +
-if (Pt) Rd = memw (Rs + #u6:2) // +
-if (!Pt) Rd = memw (Rs + #u6:2) // +
-if (Pt.new) Rd = memw (Rs + #u6:2) // +
-if (!Pt.new) Rd = memw (Rs + #u6:2) // +
-if (Pt) Rdd = memd (Rs + #u6:3) // +
-if (!Pt) Rdd = memd (Rs + #u6:3) // +
-if (Pt.new) Rdd = memd (Rs + #u6:3) // +
-if (!Pt.new) Rdd = memd (Rs + #u6:3) // +
-Rd   = memb (Rs + #s11:0) // +
-Rd   = memub (Rs + #s11:0) // +
-Rd   = memh (Rs + #s11:1) // +
-Rd   = memuh (Rs + #s11:1) // +
-Rd   = memw (Rs + #s11:2) // +
-Rdd   = memd (Rs + #s11:3) // +
-Rd   = memb (Re=#U6) // +
-Rd   = memub (Re=#U6) // +
-Rd   = memh (Re=#U6) // +
-Rd   = memuh (Re=#U6) // +
-Rd   = memw (Re=#U6) // +
-Rdd   = memd (Re=#U6) // +
-Rd   = memb (Rt<<#u2 + #U6) // +
-Rd   = memub (Rt<<#u2 + #U6) // +
-Rd   = memh (Rt<<#u2 + #U6) // +
-Rd   = memuh (Rt<<#u2 + #U6) // +
-Rd   = memw (Rt<<#u2 + #U6) // +
-Rdd   = memd (Rt<<#u2 + #U6) // +
-if   (Pt) Rd = memb (#u6) // +
-if   (!Pt) Rd = memb (#u6) // +
-if   (Pt.new) Rd = memb (#u6) // +
-if   (!Pt.new) Rd = memb (#u6) // +
-if   (Pt) Rd = memub (#u6) // +
-if   (!Pt) Rd = memub (#u6) // +
-if   (Pt.new) Rd = memub (#u6) // +
-if   (!Pt.new) Rd = memub (#u6) // +
-if   (Pt) Rd = memh (#u6) // +
-if   (!Pt) Rd = memh (#u6) // +
-if   (Pt.new) Rd = memh (#u6) // +
-if   (!Pt.new) Rd = memh (#u6) // +
-if   (Pt) Rd = memuh (#u6) // +
-if   (!Pt) Rd = memuh (#u6) // +
-if   (Pt.new) Rd = memuh (#u6) // +
-if   (!Pt.new) Rd = memuh (#u6) // +
-if   (Pt) Rd = memw (#u6) // +
-if   (!Pt) Rd = memw (#u6) // +
-if   (Pt.new) Rd = memw (#u6) // +
-if   (!Pt.new) Rd = memw (#u6) // +
-if   (Pt) Rdd = memd (#u6) // +
-if   (!Pt) Rdd = memd (#u6) // +
-if   (Pt.new) Rdd = memd (#u6) // +
-if   (!Pt.new) Rdd = memd (#u6) // +
-memb(gp+#u16:0) = Rt // +
-memh(gp+#u16:0) = Rt // +
-memw(gp+#u16:0) = Rt // +
-memd(gp+#u16:0) = Rtt // +
-memb(gp+#u16:0) = Nt.new // +
-memh(gp+#u16:0) = Nt.new // +
-memw(gp+#u16:0) = Nt.new // +
-memd(gp+#u16:0) = Nt.new // +
-if (Pv) memb(Rs + #u6:0) = Rt // +
-if (!Pv) memb(Rs + #u6:0) = Rt // +
-if (Pv.new) memb(Rs + #u6:0) = Rt // +
-if (!Pv.new) memb(Rs + #u6:0) = Rt // +
-if (Pv) memb(Rs + #u6:0) = Rt.new
-if (!Pv) memb(Rs + #u6:0) = Rt.new
-if (Pv.new) memb(Rs + #u6:0) = Rt.new
-if (!Pv.new) memb(Rs + #u6:0) = Rt.new
-if (Pv) memh(Rs + #u6:1) = Rt // +
-if (!Pv) memh(Rs + #u6:1) = Rt // +
-if (Pv.new) memh(Rs + #u6:1) = Rt // +
-if (!Pv.new) memh(Rs + #u6:1) = Rt // +
-if (Pv) memh(Rs + #u6:1) = Rt.new
-if (!Pv) memh(Rs + #u6:1) = Rt.new
-if (Pv.new) memh(Rs + #u6:1) = Rt.new
-if (!Pv.new) memh(Rs + #u6:1) = Rt.new
-if (Pv) memw(Rs + #u6:2) = Rt // +
-if (!Pv) memw(Rs + #u6:2) = Rt // +
-if (Pv.new) memw(Rs + #u6:2) = Rt // +
-if (!Pv.new) memw(Rs + #u6:2) = Rt // +
-if (Pt) memw(Rs + ##U32) = Rt.new
-if (!Pt) memw(Rs + ##U32) = Rt.new
-if (Pt.new) memw(Rs + ##U32) = Rt.new
-if (!Pt.new) memw(Rs + ##U32) = Rt.new
-if (Pv) memd(Rs + #u6:3) = Rtt // +
-if (!Pv) memd(Rs + #u6:3) = Rtt // +
-if (Pv.new) memd(Rs + #u6:3) = Rtt // +
-if (!Pv.new) memd(Rs + #u6:3) = Rtt // +
-if (Pt) memd(Rs + ##U32) = Ntt.new
-if (!Pt) memd(Rs + ##U32) = Ntt.new
-if (Pt.new) memd(Rs + ##U32) = Ntt.new
-if (!Pt.new) memd(Rs + ##U32) = Ntt.new
-memb(Rs + #s11:0) = Rt // +
-memh(Rs + #s11:1) = Rt // +
-memw(Rs + #s11:2) = Rt // +
-memd(Rs + #s11:3) = Rtt // +
-memb(Rs + #s11:0) = Nt.new // +
-memh(Rs + #s11:1) = Nt.new // +
-memw(Rs + #s11:2) = Nt.new // +
-memd(Rs + #s11:3) = Ntt.new // +
-memb(Re=#U6) = Rt // +
-memh(Re=#U6) = Rt // +
-memw(Re=#U6) = Rt // +
-memd(Re=#U6) = Rtt // +
-memb(Re=##U32) = Rt.new
-memh(Re=##U32) = Rt.new
-memw(Re=##U32) = Rt.new
-memd(Re=##U32) = Rt.new
-memb(Ru<<#u2 + #U6) = Rt // +
-memh(Ru<<#u2 + #U6) = Rt // +
-memw(Ru<<#u2 + #U6) = Rt // +
-memd(Ru<<#u2 + #U6) = Rtt // +
-memb(Ru<<#u2 + #U6) = Nt.new // +
-memh(Ru<<#u2 + #U6) = Nt.new // +
-memw(Ru<<#u2 + #U6) = Nt.new // +
-memd(Ru<<#u2 + #U6) = Nt.new // +
-if (Pt) memb(#u6) = Rt // +
-if (Pt) memb(#u6) = Rt // +
-if (!Pt) memb(#u6) = Rt // +
-if (!Pt) memb(#u6) = Rt // +
-if (Pt) memb(#u6) = Nt.new // +
-if (Pt) memb(#u6) = Nt.new // +
-if (!Pt) memb(#u6) = Nt.new // +
-if (!Pt) memb(#u6) = Nt.new // +
-if (Pt) memh(#u6) = Rt // +
-if (Pt) memh(#u6) = Rt // +
-if (!Pt) memh(#u6) = Rt // +
-if (!Pt) memh(#u6) = Rt // +
-if (Pt) memh(#u6) = Nt.new // +
-if (Pt) memh(#u6) = Nt.new // +
-if (!Pt) memh(#u6) = Nt.new // +
-if (!Pt) memh(#u6) = Nt.new // +
-if (Pt) memw(#u6) = Rt // +
-if (Pt) memw(#u6) = Rt // +
-if (!Pt) memw(#u6) = Rt // +
-if (!Pt) memw(#u6) = Rt // +
-if (Pt) memw(#u6) = Nt.new // +
-if (Pt) memw(#u6) = Nt.new // +
-if (!Pt) memw(#u6) = Nt.new // +
-if (!Pt) memw(#u6) = Nt.new // +
-if (Pt) memd(#u6) = Rtt // +
-if (Pt) memd(#u6) = Rtt // +
-if (!Pt) memd(#u6) = Rtt // +
-if (!Pt) memd(#u6) = Rtt // +
-if (Pt) memd(#u6) = Rt.new
-if (Pt) memd(#u6) = Rt.new
-if (!Pt) memd(#u6) = Rt.new
-if (!Pt) memd(#u6) = Rt.new
-memw(Rs + #u6) = ##U32
-if Ps memw(Rs + #u6) = ##U32
-if !Ps memw(Rs + #u6) = ##U32
-memw(Rs + Rt<<#u2) = ##U32
-if (cmp.eq(Ns.new,#U5)) jump:nt #r9:2 // +
-if (cmp.eq(Ns.new,#U5)) jump:t #r9:2 // +
-if (!cmp.eq(Ns.new,#U5)) jump:nt #r9:2 // +
-if (!cmp.eq(Ns.new,#U5)) jump:t #r9:2 // +
-if (cmp.gt(Ns.new,#U5)) jump:nt #r9:2 // +
-if (cmp.gt(Ns.new,#U5)) jump:t #r9:2 // +
-if (!cmp.gt(Ns.new,#U5)) jump:nt #r9:2 // +
-if (!cmp.gt(Ns.new,#U5)) jump:t #r9:2 // +
-if (cmp.gtu(Ns.new,##U5)) jump:nt #r9:2 // +
-if (cmp.gtu(Ns.new,##U5)) jump:t #r9:2 // +
-if (!cmp.gtu(Ns.new,##U5)) jump:nt #r9:2 // +
-if (!cmp.gtu(Ns.new,##U5)) jump:t #r9:2 // +
-Rd = #s16 // +
-Rdd = combine(Rs,#s8) // + [1]
-Rdd = combine(#s8,Rs) // + [1]
-Rdd = combine(#s8,#s8) // + [1]
-Rdd = combine(#s8,#U6) // + [2]
-Rd = mux (Pu, Rs,#s8) // + [1]
-Rd = mux (Pu, #s8, Rs) // + [1]
-Rd = mux(Pu,#s8,#S8) // + [1]
-if (Pu) Rd = add(Rs,#s8) // +
-if (!Pu) Rd = add(Rs,#s8) // +
-if (Pu.new) Rd = add(Rs,#s8) // +
-if (!Pu.new) Rd = add(Rs,#s8) // +
-if (Pu) Rd = #s12 // +
-if (!Pu) Rd = #s12 // +
-if (Pu.new) Rd = #s12 // +
-if (!Pu.new) Rd = #s12 // +
-Pd = cmp.eq (Rs,#s10) // +
-Pd = !cmp.eq (Rs,#s10) // +
-Pd = cmp.gt (Rs,#s10) // +
-Pd = !cmp.gt (Rs,#s10) // +
-Pd = cmp.gtu (Rs,#u9) // +
-Pd = !cmp.gtu (Rs,#u9) // +
-Rd = cmp.eq(Rs,#s8) // +
-Rd = !cmp.eq(Rs,#s8) // +
-Rd = and(Rs,#s10) // +
-Rd = or(Rs,#s10) // +
-Rd = sub(#s10,Rs) // +
-Rd = add(Rs,#s16) // +
-Rd = mpyi(Rs,#m9) // +
-Rd += mpyi(Rs,#u8) // +
-Rd -= mpyi(Rs,#u8) // +
-Rx += add(Rs,#s8) // +
-Rx -= add(Rs,#s8) // +
-Rd = #s16 // +
-jump #r22:2 // +
 call #r22:2 // +
-if (Pu) call #r15:2 // +
+if (!cmp.eq(Ns.new,#U5)) jump:nt #r9:2 // +
+if (cmp.eq(Ns.new,#U5)) jump:nt #r9:2 // +
+if (!cmp.eq(Ns.new,#U5)) jump:t #r9:2 // +
+if (cmp.eq(Ns.new,#U5)) jump:t #r9:2 // +
+if (!cmp.gt(Ns.new,#U5)) jump:nt #r9:2 // +
+if (cmp.gt(Ns.new,#U5)) jump:nt #r9:2 // +
+if (!cmp.gt(Ns.new,#U5)) jump:t #r9:2 // +
+if (cmp.gt(Ns.new,#U5)) jump:t #r9:2 // +
+if (!cmp.gtu(Ns.new,##U5)) jump:nt #r9:2 // +
+if (cmp.gtu(Ns.new,##U5)) jump:nt #r9:2 // +
+if (!cmp.gtu(Ns.new,##U5)) jump:t #r9:2 // +
+if (cmp.gtu(Ns.new,##U5)) jump:t #r9:2 // +
+if !Ps memw(Rs + #u6) = ##U32 // +
+if Ps memw(Rs + #u6) = ##U32 // +
+if (!Pt) memb(#u6) = Nt.new // +
+if (Pt) memb(#u6) = Nt.new // +
+if (!Pt) memb(#u6) = Rt // +
+if (Pt) memb(#u6) = Rt // +
+if (!Pt) memd(Rs + ##U32) = Ntt.new // +
+if (Pt) memd(Rs + ##U32) = Ntt.new // +
+if (!Pt) memd(#u6) = Rt.new // +
+if (Pt) memd(#u6) = Rt.new // +
+if (!Pt) memd(#u6) = Rtt // +
+if (Pt) memd(#u6) = Rtt // +
+if (!Pt) memh(#u6) = Nt.new // +
+if (Pt) memh(#u6) = Nt.new // +
+if (!Pt) memh(#u6) = Rt // +
+if (Pt) memh(#u6) = Rt // +
+if (!Pt) memw(Rs + ##U32) = Rt.new // +
+if (Pt) memw(Rs + ##U32) = Rt.new // +
+if (!Pt) memw(#u6) = Nt.new // +
+if (Pt) memw(#u6) = Nt.new // +
+if (!Pt) memw(#u6) = Rt // +
+if (Pt) memw(#u6) = Rt // +
+if (!Pt.new) memd(Rs + ##U32) = Ntt.new // +
+if (Pt.new) memd(Rs + ##U32) = Ntt.new // +
+if (!Pt.new) memw(Rs + ##U32) = Rt.new // +
+if (Pt.new) memw(Rs + ##U32) = Rt.new // +
+if (!Pt.new) memw(Rs + #u6:2) = Rt // +
+if (Pt.new) memw(Rs + #u6:2) = Rt // +
+if (!Pt.new) Rdd = memd (Rs + #u6:3) // +
+if (Pt.new) Rdd = memd (Rs + #u6:3) // +
+if (!Pt.new) Rdd = memd (#u6) // +
+if (Pt.new) Rdd = memd (#u6) // +
+if (!Pt.new) Rd = memb (Rs + #u6:0) // +
+if (Pt.new) Rd = memb (Rs + #u6:0) // +
+if (!Pt.new) Rd = memb (#u6) // +
+if (Pt.new) Rd = memb (#u6) // +
+if (!Pt.new) Rd = memh (Rs + #u6:1) // +
+if (Pt.new) Rd = memh (Rs + #u6:1) // +
+if (!Pt.new) Rd = memh (#u6) // +
+if (Pt.new) Rd = memh (#u6) // +
+if (!Pt.new) Rd = memub (Rs + #u6:0) // +
+if (Pt.new) Rd = memub (Rs + #u6:0) // +
+if (!Pt.new) Rd = memub (#u6) // +
+if (Pt.new) Rd = memub (#u6) // +
+if (!Pt.new) Rd = memuh (Rs + #u6:1) // +
+if (Pt.new) Rd = memuh (Rs + #u6:1) // +
+if (!Pt.new) Rd = memuh (#u6) // +
+if (Pt.new) Rd = memuh (#u6) // +
+if (!Pt.new) Rd = memw (Rs + #u6:2) // +
+if (Pt.new) Rd = memw (Rs + #u6:2) // +
+if (!Pt.new) Rd = memw (#u6) // +
+if (Pt.new) Rd = memw (#u6) // +
+if (!Pt) Rdd = memd (Rs + #u6:3) // +
+if (Pt) Rdd = memd (Rs + #u6:3) // +
+if (!Pt) Rdd = memd (#u6) // +
+if (Pt) Rdd = memd (#u6) // +
+if (!Pt) Rd = memb (Rs + #u6:0) // +
+if (Pt) Rd = memb (Rs + #u6:0) // +
+if (!Pt) Rd = memb (#u6) // +
+if (Pt) Rd = memb (#u6) // +
+if (!Pt) Rd = memh (Rs + #u6:1) // +
+if (Pt) Rd = memh (Rs + #u6:1) // +
+if (!Pt) Rd = memh (#u6) // +
+if (Pt) Rd = memh (#u6) // +
+if (!Pt) Rd = memub (Rs + #u6:0) // +
+if (Pt) Rd = memub (Rs + #u6:0) // +
+if (!Pt) Rd = memub (#u6) // +
+if (Pt) Rd = memub (#u6) // +
+if (!Pt) Rd = memuh (Rs + #u6:1) // +
+if (Pt) Rd = memuh (Rs + #u6:1) // +
+if (!Pt) Rd = memuh (#u6) // +
+if (Pt) Rd = memuh (#u6) // +
+if (!Pt) Rd = memw (Rs + #u6:2) // +
+if (Pt) Rd = memw (Rs + #u6:2) // +
+if (!Pt) Rd = memw (#u6) // +
+if (Pt) Rd = memw (#u6) // +
 if (!Pu) call #r15:2 // +
-Pd = sp1loop0(#r7:2,#U10) // + [1]
-Pd = sp1loop0(#r7:2,Rs) // + [1]
-Pd = sp2loop0(#r7:2,#U10) // + [1]
-Pd = sp2loop0(#r7:2,Rs) // + [1]
-Pd = sp3loop0(#r7:2,#U10) // + [1]
-Pd = sp3loop0(#r7:2,Rs) // + [1]
-loop0 (#r7:2,#U10) // + [1]
-loop0 (#r7:2,Rs) // + [1]
-loop1 (#r7:2,#U10) // + [1]
-loop1 (#r7:2,Rs) // + [1]
-Rd = add(pc,#u6) // + [1]
-Rd = add(#u6,mpyi(Rs,#u6)) // + [1]
-Rd = add(#6,mpyi(Rs,Rt)) // + [1]
-Rd = add(Rs,add(Ru,#s6)) // +
-Rd = add(Rs,sub(#s6,Ru)) // +
-Rd = sub(##u32,add(Rs,Rt)) //  WTF - not in the manual
-Rx = or(Rs,and(Rx,#s10)) // +
-Rx = add (#u8,asl(Rx,#U5)) // + [1]
-Rx = add (#u8,asr(Rx,#U5)) // + [1]
-Rx = add (#u8,lsr(Rx,#U5)) // + [1]
-Rx = sub (#u8,asl(Rx,#U5)) // + [1]
-Rx = sub (#u8,asr(Rx,#U5)) // + [1]
-Rx = sub (#u8,lsr(Rx,#U5)) // + [1]
-Rx = and (#u8,asl(Rx,#U5)) // + [1]
-Rx = and (#u8,asr(Rx,#U5)) // + [1]
-Rx = and (#u8,lsr(Rx,#U5)) // + [1]
-Rx = or (#u8,asl(Rx,#U5)) // + [1]
-Rx = or (#u8,asr(Rx,#U5)) // + [1]
-Rx = or (#u8,lsr(Rx,#U5)) // + [1]
-Rx = add (#u8,asl(Rs,Rx)) // +
-Rx = add (#u8,asr(Rs,Rx)) // +
-Rx = add (#u8,lsr(Rs,Rx)) // +
-Rx = sub (#u8,asl(Rs,Rx)) // +
-Rx = sub (#u8,asr(Rs,Rx)) // +
-Rx = sub (#u8,lsr(Rs,Rx)) // +
-Rx = and (#u8,asl(Rs,Rx)) // +
-Rx = and (#u8,asr(Rs,Rx)) // +
-Rx = and (#u8,lsr(Rs,Rx)) // +
-Rx = or (#u8,asl(Rs,Rx)) // +
-Rx = or (#u8,asr(Rs,Rx)) // +
-Rx = or (#u8,lsr(Rs,Rx)) // +
-Rx = add (#u8,asl(Rx,Rs)) // WTF - no such instruction
-Rx = add (#u8,asr(Rx,Rs)) // WTF
-Rx = add (#u8,lsr(Rx,Rs)) // WTF
-Rx = sub (#u8,asl(Rx,Rs)) // WTF
-Rx = sub (#u8,asr(Rx,Rs)) // WTF
-Rx = sub (#u8,lsr(Rx,Rs)) // WTF
-Rx = and (#u8,asl(Rx,Rs)) // WTF
-Rx = and (#u8,asr(Rx,Rs)) // WTF
-Rx = and (#u8,lsr(Rx,Rs)) // WTF
-Rx = or (#u8,asl(Rx,Rs)) // WTF
-Rx = or (#u8,asr(Rx,Rs)) // WTF
-Rx = or (#u8,lsr(Rx,Rs)) // WTF
+if (Pu) call #r15:2 // +
+if (!Pu.new) Rd = add(Rs,#s8) // +
+if (Pu.new) Rd = add(Rs,#s8) // +
+if (!Pu.new) Rd = #s12 // +
+if (Pu.new) Rd = #s12 // +
+if (!Pu) Rd = add(Rs,#s8) // +
+if (Pu) Rd = add(Rs,#s8) // +
+if (!Pu) Rd = #s12 // +
+if (Pu) Rd = #s12 // +
+if (!Pv) memw(#u6) = Rt // +
+if (Pv) memw(#u6) = Rt // +
+if (!Pv) memw(#u6) = Nt.new // +
+if (Pv) memw(#u6) = Nt.new // +
+if (!Pv) memb(Rs + #u6:0) = Rt // +
+if (Pv) memb(Rs + #u6:0) = Rt // +
+if (!Pv) memb(Rs + #u6:0) = Rt.new // +
+if (Pv) memb(Rs + #u6:0) = Rt.new // +
+if (!Pv) memd(Rs + #u6:3) = Rtt // +
+if (Pv) memd(Rs + #u6:3) = Rtt // +
+if (!Pv) memh(Rs + #u6:1) = Rt // +
+if (Pv) memh(Rs + #u6:1) = Rt // +
+if (!Pv) memh(Rs + #u6:1) = Rt.new // +
+if (Pv) memh(Rs + #u6:1) = Rt.new // +
+if (!Pv) memw(Rs + #u6:2) = Rt // +
+if (Pv) memw(Rs + #u6:2) = Rt // +
+if (!Pv.new) memw(#u6) = Rt // +
+if (Pv.new) memw(#u6) = Rt // +
+if (!Pv.new) memw(#u6) = Nt.new // +
+if (Pv.new) memw(#u6) = Nt.new // +
+if (!Pv.new) memb(Rs + #u6:0) = Rt // +
+if (Pv.new) memb(Rs + #u6:0) = Rt // +
+if (!Pv.new) memb(Rs + #u6:0) = Rt.new // +
+if (Pv.new) memb(Rs + #u6:0) = Rt.new // +
+if (!Pv.new) memd(Rs + #u6:3) = Rtt // +
+if (Pv.new) memd(Rs + #u6:3) = Rtt // +
+if (!Pv.new) memh(Rs + #u6:1) = Rt // +
+if (Pv.new) memh(Rs + #u6:1) = Rt // +
+if (!Pv.new) memh(Rs + #u6:1) = Rt.new // +
+if (Pv.new) memh(Rs + #u6:1) = Rt.new // +
+if (!Pv.new) memw(Rs + #u6:2) = Rt // +
+if (Pv.new) memw(Rs + #u6:2) = Rt // +
+jump #r22:2 // +
+loop0 (#r7:2,Rs) // +
+loop0 (#r7:2,#U10) // +
+loop1 (#r7:2,Rs) // +
+loop1 (#r7:2,#U10) // +
+memb(gp+#u16:0) = Nt.new // +
+memb(gp+#u16:0) = Rt // +
+memb(Re=##U32) = Rt.new // +
+memb(Re=#U6) = Rt // +
+memb(Rs + #s11:0) = Nt.new // +
+memb(Rs + #s11:0) = Rt // +
+memb(Rs + #u6:0) = #S8 // +
+memb(Ru<<#u2 + #U6) = Nt.new // +
+memb(Ru<<#u2 + #U6) = Rt // +
+memd(gp+#u16:0) = Nt.new // +
+memd(gp+#u16:0) = Rtt // +
+memd(Re=##U32) = Rt.new // +
+memd(Re=#U6) = Rtt // +
+memd(Rs + #s11:3) = Ntt.new // +
+memd(Rs + #s11:3) = Rtt // +
+memd(Ru<<#u2 + #U6) = Nt.new // +
+memd(Ru<<#u2 + #U6) = Rtt // +
+memh(gp+#u16:0) = Nt.new // +
+memh(gp+#u16:0) = Rt // +
+memh(Re=##U32) = Rt.new // +
+memh(Re=#U6) = Rt // +
+memh(Rs + #s11:1) = Nt.new // +
+memh(Rs + #s11:1) = Rt // +
+memh(Rs + #u6:1) = #S8 // +
+memh(Ru<<#u2 + #U6) = Nt.new // +
+memh(Ru<<#u2 + #U6) = Rt // +
+memw(gp+#u16:0) = Nt.new // +
+memw(gp+#u16:0) = Rt // +
+memw(Re=##U32) = Rt.new // +
+memw(Re=#U6) = Rt // +
+memw(Rs + Rt<<#u2) = ##U32 // +
+memw(Rs + #s11:2) = Nt.new // +
+memw(Rs + #s11:2) = Rt // +
+memw(Rs + #u6:2) = #S8 // +
+memw(Rs + #u6) = ##U32 // +
+memw(Ru<<#u2 + #U6) = Nt.new // +
+memw(Ru<<#u2 + #U6) = Rt // +
 Pd = cmpb.eq (Rs,#u8) // +
 Pd = cmpb.gt (Rs,#s8) // +
 Pd = cmpb.gtu (Rs,#u7) // +
+Pd = !cmp.eq (Rs,#s10) // +
+Pd = cmp.eq (Rs,#s10) // +
+Pd = !cmp.gt (Rs,#s10) // +
+Pd = cmp.gt (Rs,#s10) // +
+Pd = !cmp.gtu (Rs,#u9) // +
+Pd = cmp.gtu (Rs,#u9) // +
 Pd = cmph.eq (Rs,#s8) // +
 Pd = cmph.gt (Rs,#s8) // +
 Pd = cmph.gtu (Rs,#u7) // +
-
+Pd = sp1loop0(#r7:2,Rs) // +
+Pd = sp1loop0(#r7:2,#U10) // +
+Pd = sp2loop0(#r7:2,Rs) // +
+Pd = sp2loop0(#r7:2,#U10) // +
+Pd = sp3loop0(#r7:2,Rs) // +
+Pd = sp3loop0(#r7:2,#U10) // +
+Rd = add(#6,mpyi(Rs,Rt)) // +
+Rd = add(pc,#u6) // +
+Rd = add(Rs,add(Ru,#s6)) // +
+Rd = add(Rs,#s16) // +
+Rd = add(Rs,sub(#s6,Ru)) // +
+Rd = add(#u6,mpyi(Rs,#u6)) // +
+Rd = and(Rs,#s10) // +
+Rd = !cmp.eq(Rs,#s8) // +
+Rd = cmp.eq(Rs,#s8) // +
+Rdd = combine(Rs,#s8) // +
+Rdd = combine(#s8,Rs) // +
+Rdd = combine(#s8,#s8) // +
+Rdd = combine (#s8,#S8) // +
+Rdd = combine(#s8,#U6) // +
+Rdd = memd (Re=#U6) // +
+Rdd = memd (Rs + #s11:3) // +
+Rdd = memd (Rt<<#u2 + #U6) // +
+Rd = memb (Re=#U6) // +
+Rd = memb (Rs + #s11:0) // +
+Rd = memb (Rt<<#u2 + #U6) // +
+Rd = memb(##U32) // +
+Rd = memd(##U32) // +
+Rd = memh (Re=#U6) // +
+Rd = memh (Rs + #s11:1) // +
+Rd = memh (Rt<<#u2 + #U6) // +
+Rd = memh(##U32) // +
+Rd = memub (Re=#U6) // +
+Rd = memub (Rs + #s11:0) // +
+Rd = memub (Rt<<#u2 + #U6) // +
+Rd = memub(##U32) // +
+Rd = memuh (Re=#U6) // +
+Rd = memuh (Rs + #s11:1) // +
+Rd = memuh (Rt<<#u2 + #U6) // +
+Rd = memuh(##U32) // +
+Rd = memw (Re=#U6) // +
+Rd = memw (Rs + #s11:2) // +
+Rd = memw (Rt<<#u2 + #U6) // +
+Rd = memw(##U32) // +
+Rd = memw (gp + #u16:2) // +
+Rd = memw (Re=#U6) // +
+Rd = memw (Rs + #s11:2) // +
+Rd = mpyi(Rs,#m9) // +
+Rd -= mpyi(Rs,#u8) // +
+Rd += mpyi(Rs,#u8) // +
+Rd = mux (Pu, Rs,#s8) // +
+Rd = mux (Pu, #s8, Rs) // +
+Rd = mux(Pu,#s8,#S8) // +
+Rd = or(Rs,#s10) // +
+Rd = #s16 // +
+Rd = sub(#s10,Rs) // +
+Rd = sub(##u32,add(Rs,Rt)) // Not in the manual
+Rx -= add(Rs,#s8) // +
+Rx += add(Rs,#s8) // +
+Rx = add (#u8,asl(Rs,Rx)) // +
+Rx = add (#u8,asl(Rx,Rs)) // Not in the manual
+Rx = add (#u8,asl(Rx,#U5)) // +
+Rx = add (#u8,asr(Rs,Rx)) // +
+Rx = add (#u8,asr(Rx,Rs)) // Not in the manual
+Rx = add (#u8,asr(Rx,#U5)) // +
+Rx = add (#u8,lsr(Rs,Rx)) // +
+Rx = add (#u8,lsr(Rx,Rs)) // Not in the manual
+Rx = add (#u8,lsr(Rx,#U5)) // +
+Rx = and (#u8,asl(Rs,Rx)) // +
+Rx = and (#u8,asl(Rx,Rs)) //  Not in the manual
+Rx = and (#u8,asl(Rx,#U5)) // +
+Rx = and (#u8,asr(Rs,Rx)) // +
+Rx = and (#u8,asr(Rx,Rs)) // Not in the manual
+Rx = and (#u8,asr(Rx,#U5)) // +
+Rx = and (#u8,lsr(Rs,Rx)) // +
+Rx = and (#u8,lsr(Rx,Rs)) // Not in the manual
+Rx = and (#u8,lsr(Rx,#U5)) // +
+Rx = or(Rs,and(Rx,#s10)) // +
+Rx = or (#u8,asl(Rs,Rx)) // +
+Rx = or (#u8,asl(Rx,Rs)) // Not in the manual
+Rx = or (#u8,asl(Rx,#U5)) // +
+Rx = or (#u8,asr(Rs,Rx)) // +
+Rx = or (#u8,asr(Rx,Rs)) // Not in the manual
+Rx = or (#u8,asr(Rx,#U5)) // +
+Rx = or (#u8,lsr(Rs,Rx)) // +
+Rx = or (#u8,lsr(Rx,Rs)) // Not in the manual
+Rx = or (#u8,lsr(Rx,#U5)) // +
+Rx = sub (#u8,asl(Rs,Rx)) // +
+Rx = sub (#u8,asl(Rx,Rs)) // Not in the manual
+Rx = sub (#u8,asl(Rx,#U5)) // +
+Rx = sub (#u8,asr(Rs,Rx)) // Not in the manual
+Rx = sub (#u8,asr(Rx,Rs)) // +
+Rx = sub (#u8,asr(Rx,#U5)) // +
+Rx = sub (#u8,lsr(Rs,Rx)) // +
+Rx = sub (#u8,lsr(Rx,Rs)) // Not in the manual
+Rx = sub (#u8,lsr(Rx,#U5)) // +
+Rd = #u6 // Slot 1 duplex
+Rd = #U6 // Slot 1 duplex
+Re = #u6 // Slot 1 duplex
+Re = #U6 // Slot 1 duplex
+Rx = #u6 // Slot 1 duplex
+Rx = #U6 // Slot 1 duplex
+Rd = add (Rx, #s7) // Slot 1 duplex
+Rd = add (Rx, #S7) // Slot 1 duplex
+Re = add (Rx, #s7) // Slot 1 duplex
+Re = add (Rx, #S7) // Slot 1 duplex
+Rx = add (Rx, #s7) // Slot 1 duplex
+Rx = add (Rx, #S7) // Slot 1 duplex

--- a/r2/hexagon_disas.c
+++ b/r2/hexagon_disas.c
@@ -1767,6 +1767,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; p0 = cmp.eq (%s, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -1784,6 +1785,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, Rx)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -1801,6 +1803,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (Rx, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2436,6 +2439,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = #-1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2453,6 +2457,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = 0x%x", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2470,6 +2475,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, #-1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2487,6 +2493,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2504,6 +2511,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = add (Sp, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2521,6 +2529,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = and (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2538,6 +2547,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = and (%s, #255)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2556,6 +2566,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#0, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2574,6 +2585,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#0, %s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2592,6 +2604,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#1, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2610,6 +2623,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#2, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2628,6 +2642,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (#3, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -2646,6 +2661,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = combine (%s, #0)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2661,6 +2677,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2676,6 +2693,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2691,6 +2709,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2706,6 +2725,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -2723,6 +2743,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2740,6 +2761,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = sxtb (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2757,6 +2779,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = sxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -2774,6 +2797,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = zxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5803,6 +5827,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = #-1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -5823,6 +5848,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = 0x%x", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -5843,6 +5869,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (%s, #-1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5863,6 +5890,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5883,6 +5911,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = add (Sp, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -5903,6 +5932,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = and (%s, #1)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5923,6 +5953,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = and (%s, #255)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5944,6 +5975,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#0, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -5965,6 +5997,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#0, %s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -5986,6 +6019,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#1, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -6007,6 +6041,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#2, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -6028,6 +6063,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x60) >> 5);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (#3, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -6049,6 +6085,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = combine (%s, #0)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -6067,6 +6104,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -6085,6 +6123,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -6103,6 +6142,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -6121,6 +6161,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0xf) >> 0); // Rd
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) %s = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg));
 					break;
 				}
@@ -6141,6 +6182,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x3) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; p0 = cmp.eq (%s, 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -6161,6 +6203,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -6181,6 +6224,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = sxtb (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -6201,6 +6245,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = sxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -6221,6 +6266,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf0) >> 4); // Rs
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = zxth (%s)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -7322,6 +7368,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memub (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -7341,6 +7388,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memw (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -7983,6 +8031,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memub (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -8005,6 +8054,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0xf00) >> 8) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memw (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -8354,6 +8404,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8367,6 +8418,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; deallocframe", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8380,6 +8432,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8393,6 +8446,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8406,6 +8460,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8419,6 +8474,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (! p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8432,6 +8488,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8445,6 +8502,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8458,6 +8516,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8471,6 +8530,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; if (p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -8484,6 +8544,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32) & 0x3f00000) >> 20);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm);
 					break;
 				}
@@ -10796,6 +10857,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memb (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10815,6 +10877,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10834,6 +10897,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memuh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -10851,6 +10915,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x1f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memw (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -10869,6 +10934,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf8) >> 3) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; %s = memd (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -12536,6 +12602,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memb (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -12558,6 +12625,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -12580,6 +12648,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_IMM;
 					hi->ops[4].op.imm = (((hi_u32) & 0x700) >> 8) << 1; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memuh (%s + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hex_get_sub_reg(hi->ops[3].op.reg), hi->ops[4].op.imm);
 					break;
 				}
@@ -12600,6 +12669,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0x1f0) >> 4) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memw (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -12621,6 +12691,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf8) >> 3) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; %s = memd (Sp + 0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_regpair(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -12637,6 +12708,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12653,6 +12725,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; deallocframe", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12669,6 +12742,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12685,6 +12759,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12701,6 +12776,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12717,6 +12793,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (! p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12733,6 +12810,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) dealloc_return", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12749,6 +12827,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0) jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12765,6 +12844,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) dealloc_return:nt", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12781,6 +12861,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; if (p0.new) jumpr:nt Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -12797,6 +12878,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[1].op.imm |= (0xFFFFFFFF << 6);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; jumpr Lr", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm);
 					break;
 				}
@@ -14135,6 +14217,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -14154,6 +14237,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -14796,6 +14880,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -14818,6 +14903,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -15172,6 +15258,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_IMM;
 					hi->ops[2].op.imm = (((hi_u32) & 0x1f0) >> 4) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; allocframe (0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm);
 					break;
 				}
@@ -15189,6 +15276,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15206,6 +15294,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memb (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15227,6 +15316,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
@@ -15246,6 +15336,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memh (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -15263,6 +15354,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15280,6 +15372,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -15297,6 +15390,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = 0x%x ; memw (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -17603,6 +17697,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_IMM;
 					hi->ops[2].op.imm = (((hi_u32) & 0x1f0) >> 4) << 3; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; allocframe (0x%x)", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hi->ops[2].op.imm);
 					break;
 				}
@@ -17623,6 +17718,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -17643,6 +17739,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memb (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -17667,6 +17764,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].attr |= HEX_OP_REG_PAIR;
 					hi->ops[3].op.reg = (((hi_u32) & 0x7) >> 0);
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memd (Sp + %d) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, (st32) hi->ops[2].op.imm, hex_get_sub_regpair(hi->ops[3].op.reg));
 					break;
 				}
@@ -17689,6 +17787,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[4].type = HEX_OP_TYPE_REG;
 					hi->ops[4].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memh (%s + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm, hex_get_sub_reg(hi->ops[4].op.reg));
 					break;
 				}
@@ -17709,6 +17808,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = #0", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -17729,6 +17829,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_IMM;
 					hi->ops[3].op.imm = (((hi_u32) & 0xf) >> 0) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (%s + 0x%x) = #1", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hex_get_sub_reg(hi->ops[2].op.reg), hi->ops[3].op.imm);
 					break;
 				}
@@ -17749,6 +17850,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[3].type = HEX_OP_TYPE_REG;
 					hi->ops[3].op.reg = (((hi_u32) & 0xf) >> 0); // Rt
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "%s = add (Rx, %d) ; memw (Sp + 0x%x) = %s", hex_get_sub_reg(hi->ops[0].op.reg), (st32) hi->ops[1].op.imm, hi->ops[2].op.imm, hex_get_sub_reg(hi->ops[3].op.reg));
 					break;
 				}
@@ -24678,6 +24780,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "memb (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
@@ -24875,6 +24978,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend_off(&hi->ops[1], 1);
 					sprintf(hi->mnem, "memh (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
@@ -25128,6 +25232,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend_off(&hi->ops[1], 2);
 					sprintf(hi->mnem, "memw (R%d + 0x%x) = %d", hi->ops[0].op.reg, hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
@@ -25696,6 +25801,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[1].type = HEX_OP_TYPE_IMM;
 					hi->ops[1].op.imm = (((hi_u32 & 0x6000000) >> 11) | ((hi_u32 & 0x1f0000) >> 7) | ((hi_u32 & 0x3fe0) >> 5)) << 2; // scaled
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend_off(&hi->ops[1], 2);
 					sprintf(hi->mnem, "R%d = memw (gp + 0x%x)", hi->ops[0].op.reg, hi->ops[1].op.imm);
 					break;
 				}
@@ -28055,6 +28161,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 						hi->ops[2].op.imm |= (0xFFFFFFFF << 7);
 					}
 					hi->predicate = HEX_NOPRED;
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "R%d:R%d = combine (%d, %d)", hi->ops[0].op.reg + 1, hi->ops[0].op.reg, (st32) hi->ops[1].op.imm, (st32) hi->ops[2].op.imm);
 					break;
 				}
@@ -34491,6 +34598,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34505,6 +34613,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34519,6 +34628,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d.new) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -34533,6 +34643,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x700) >> 8); // Nt.new
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d.new memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35804,6 +35915,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE; // if (Pv)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35818,6 +35930,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE; // if !Pv 
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35832,6 +35945,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_TRUE_NEW; // if (Pv.new)
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if (P%d.new) memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}
@@ -35846,6 +35960,7 @@ int hexagon_disasm_instruction(ut32 hi_u32, HexInsn *hi, ut32 addr) {
 					hi->ops[2].type = HEX_OP_TYPE_REG;
 					hi->ops[2].op.reg = (((hi_u32) & 0x1f00) >> 8); // Rt
 					hi->predicate = HEX_PRED_FALSE_NEW; // if !Pv.new
+					hex_op_extend(&hi->ops[1]);
 					sprintf(hi->mnem, "if !P%d.new memw (0x%x) = R%d", hi->ops[0].op.pred, hi->ops[1].op.imm, hi->ops[2].op.reg);
 					break;
 				}


### PR DESCRIPTION
Reference: https://github.com/radareorg/r2hexagon/pull/5, https://github.com/radareorg/r2hexagon/issues/4

Clean const_extenders.txt:
- Remove repeating lines.
- Add new extenders
- Sort it and format it more uniformly

Make duplex containers expandable